### PR TITLE
Update com.dingtalk.DingTalk.yaml

### DIFF
--- a/com.dingtalk.DingTalk.yaml
+++ b/com.dingtalk.DingTalk.yaml
@@ -61,17 +61,6 @@ modules:
           type: git
           url: https://api.github.com/repos/besser82/libxcrypt/releases/latest
           tag-query: ".tag_name"
-  - name: libleancrypto
-    buildsystem: meson
-    sources:
-      - type: git
-        url: https://github.com/smuellerDD/leancrypto.git
-        tag: v1.5.1
-        commit: 8c878cf8cef101a1605a81295895570e15821601
-        x-checker-data:
-          type: git
-          url: https://api.github.com/smuellerDD/leancrypto/releases/latest
-          tag-query: .tag_name
   - name: dingtalk
     buildsystem: simple
     build-commands:

--- a/com.dingtalk.DingTalk.yaml
+++ b/com.dingtalk.DingTalk.yaml
@@ -98,10 +98,9 @@ modules:
         sha256: e3da6605db9c031532ed9a9083eb5d0eab85791fa525cce9705f26f95be1228f
         size: 344117256
         x-checker-data:
-          type: json
-          url: https://dtapp-pub.dingtalk.com/dingtalk-desktop/xc_dingtalk_update/linux_deb/Update/other/amd64/linux_dingtalk_update_package_gray.json
-          version-query: .install.package.version | sub("-Release"; "")
-          url-query: .install.package.url
+          type: rotating-url
+          url: https://www.dingtalk.com/win/d/qd=linux_amd64
+          pattern: https://dtapp-pub.dingtalk.com/dingtalk-desktop/xc_dingtalk_update/linux_deb/Release/com.alibabainc.dingtalk_([0-9.]+)_amd64.deb
 
       - type: extra-data
         filename: dingtalk.deb
@@ -110,7 +109,6 @@ modules:
         sha256: 79b20a15f27cb37c34c865daa53598b4f4b3f1080bb0deae8e3da4f664054769
         size: 330843176
         x-checker-data:
-          type: json
-          url: https://dtapp-pub.dingtalk.com/dingtalk-desktop/xc_dingtalk_update/linux_deb/Update/other/amd64/linux_dingtalk_update_package_gray.json
-          version-query: .install.package.version | sub("-Release"; "")
-          url-query: .install.package.url | sub("amd64"; "arm64")
+          type: rotating-url
+          url: https://www.dingtalk.com/win/d/qd=linux_arm64
+          pattern: https://dtapp-pub.dingtalk.com/dingtalk-desktop/xc_dingtalk_update/linux_deb/Release/com.alibabainc.dingtalk_([0-9.]+)_arm64.deb


### PR DESCRIPTION
- Removed libleancrypto entry from the YAML configuration.
- Update external data checker.