### PR TITLE
Mark DingTalk as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This Flatpak is no longer maintained."
+}


### PR DESCRIPTION
> This software is outdated and no longer available for download, but the issue hasn't been solved so far. Please temporarily remove it from the flatpak repository and it may be available again one day.

Source: https://github.com/flathub/com.dingtalk.DingTalk/pull/28#issuecomment-4108341485