### PR TITLE
Fix screen sharing: add dtwebview plugin dir to LD_LIBRARY_PATH

### DIFF
--- a/dingtalk.sh
+++ b/dingtalk.sh
@@ -17,5 +17,8 @@ if [ -n "${WAYLAND_DISPLAY:-}" ] || [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; the
 fi
 export LD_PRELOAD=$dingtalk_preload${LD_PRELOAD:+:$LD_PRELOAD}
 
+dtwebview_dir=/app/extra/dingtalk/release/plugins/dtwebview
+[ -d "$dtwebview_dir" ] && export LD_LIBRARY_PATH="$dtwebview_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
 cd "/app/extra/dingtalk/release" || exit 1
 ./com.alibabainc.dingtalk "$@"


### PR DESCRIPTION
## Problem

When screen sharing is started, the launcher spawns the `tblive` child process, which loads `libscreencast.so` and then `dlopen`s `libdt_web_view.so`. That library depends on `libcef.so`, and both live under `plugins/dtwebview/` — a directory that is **not** on the dynamic linker search path. The `dlopen` therefore fails:

```
yanghang start get libdt_web_view.so
yanghang get libdt_web_view.so fail, dlerror=libcef.so: cannot open shared object file: No such file or directory
```

The screencast child then exits immediately, so no screen picker / cast dialog ever appears. This reproduces on Wayland and is not specific to it (the same `dlopen` happens on X11).

## Fix

Prepend `/app/extra/dingtalk/release/plugins/dtwebview` to `LD_LIBRARY_PATH` in `dingtalk.sh`, guarded by a directory-existence check so it becomes a harmless no-op if the package layout ever changes. It is set unconditionally (not only inside the Wayland branch) because the failing `dlopen` is independent of the display server. The `tblive` child inherits this environment from the launcher, so its `dlopen` resolves `libcef.so` correctly.

## Verification

- Reproduced the failure on Fedora 44 / GNOME 50 (Wayland), Flatpak build `com.dingtalk.DingTalk` 8.1.0.6021101 from Flathub.
- The equivalent runtime workaround `flatpak override --env=LD_LIBRARY_PATH=/app/extra/dingtalk/release/plugins/dtwebview com.dingtalk.DingTalk` made the cast dialog render correctly (screenshot in the linked issue).
- This PR bakes the same fix into the launcher so every user gets it without a manual override.

Closes #39
